### PR TITLE
Encode request body

### DIFF
--- a/s3objects/resource.py
+++ b/s3objects/resource.py
@@ -34,7 +34,7 @@ def sendResponse(event, context, status, message):
             "Bucket": bucket,
             "Key": key,
         },
-    })
+    }).encode('utf-8')
 
     request = Request(event['ResponseURL'], data=body)
     request.add_header('Content-Type', '')


### PR DESCRIPTION
Python3 urllib won't handle strings -- the body has to be encoded.
